### PR TITLE
Minor grammatical fix

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -8,10 +8,10 @@ Stephen is a Black engineering director and leader in open source communities.
 He is Cisco's first Head of Open Source, within the Emerging Technologies &
 Incubation division.
 
-For [Kubernetes][kubernetes] community, he has co-founded transformational
-elements of the project, including the KEP (Kubernetes Enhancements Proposal)
-process, the Release Engineering subproject, and Working Group Naming. Stephen
-has also previously served as a chair for both SIG PM and SIG Azure.
+For [Kubernetes][kubernetes], he has co-founded transformational elements of
+the project, including the KEP (Kubernetes Enhancements Proposal) process, the
+Release Engineering subproject, and Working Group Naming. Stephen has also
+previously served as a chair for both SIG PM and SIG Azure.
 
 He continues his work in Kubernetes as a Chair for [SIG Release][sig-release],
 a Lead for [WG Naming][wg-naming], and an owner of [Enhancements][enhancements]

--- a/public/index.html
+++ b/public/index.html
@@ -90,10 +90,10 @@ if (!doNotTrack) {
   <p>Stephen is a Black engineering director and leader in open source communities.</p>
 <p>He is Cisco&rsquo;s first Head of Open Source, within the Emerging Technologies &amp;
 Incubation division.</p>
-<p>For <a href="https://kubernetes.io/">Kubernetes</a> community, he has co-founded transformational
-elements of the project, including the KEP (Kubernetes Enhancements Proposal)
-process, the Release Engineering subproject, and Working Group Naming. Stephen
-has also previously served as a chair for both SIG PM and SIG Azure.</p>
+<p>For <a href="https://kubernetes.io/">Kubernetes</a>, he has co-founded transformational elements of
+the project, including the KEP (Kubernetes Enhancements Proposal) process, the
+Release Engineering subproject, and Working Group Naming. Stephen has also
+previously served as a chair for both SIG PM and SIG Azure.</p>
 <p>He continues his work in Kubernetes as a Chair for <a href="https://git.k8s.io/community/sig-release">SIG Release</a>,
 a Lead for <a href="https://git.k8s.io/community/wg-naming">WG Naming</a>, and an owner of <a href="https://git.k8s.io/enhancements">Enhancements</a>
 subproject.</p>


### PR DESCRIPTION
"For Kubernetes community," --> "For Kubernetes,"

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Thanks for the catch, @celestehorgan!