### PR TITLE
[2022-01] Update roles and links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -66,6 +66,10 @@ googleAnalytics = "UA-25750838-5"
         text = "GitHub"
         url = "https://github.com/justaugustus"
 
+      [[params.links.list2.link]]
+        text = "Open Source at Cisco"
+        url = "https://opensource.cisco.com"
+
   # The original template is released under the Creative Commons Attribution 3.0 License.
   # Please keep the original attribution link when using for your own project.
   # If you'd like to use the template without the attribution, you can check out

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,19 +10,20 @@ Incubation division.
 
 For [Kubernetes][kubernetes], he has co-founded transformational elements of
 the project, including the [KEP][enhancements] (Kubernetes Enhancements
-Proposal) process, the [Release Engineering][releng] subproject, and
-[Working Group Naming][wg-naming]. Stephen has also previously served as a
-chair for both SIG PM and SIG Azure.
+Proposal) process, the [Release Engineering][releng] subproject, and Working
+Group Naming. Stephen has also previously served as a chair for both SIG PM and
+SIG Azure.
 
-He continues his work in Kubernetes as a [Steering Committee][steering] member
-and a Chair for [SIG Release][sig-release].
+He continues his work in Kubernetes as a [Steering Committee][k8s-steering]
+member and a Chair for [SIG Release][sig-release].
 
-Across the wider [CNCF][cncf] (Cloud Native Computing Foundation) ecosystem,
-Stephen has the pleasure of serving as a
-[SIG Contributor Strategy][contrib-strat] Chair, and a maintainer for the
-[Dex][dex] project. Previously, he was one of the Program Chairs for
-[KubeCon / CloudNativeCon][kubecon], the cloud native community's flagship
-conference.
+Across the wider [LF][lf] (Linux Foundation) ecosystem, Stephen has the
+pleasure of serving as a [TODO Group][todo-group]
+[Steering Committee][todo-steering] member, a [CNCF][cncf] (Cloud Native
+Computing Foundation) [TAG Contributor Strategy][contrib-strat] Chair, and a
+maintainer for the [Dex][dex] project. Previously, he was one of the Program
+Chairs for [KubeCon / CloudNativeCon][kubecon], the cloud native community's
+flagship conference.
 
 He is a [prolific contributor][devstats] to CNCF projects, amongst the top 25
 (as of writing) code/content committers, all-time.
@@ -38,14 +39,16 @@ He has previously held positions at VMWare (via Heptio), Red Hat, and CoreOS.
 Stephen is based in New York City.
 
 [cncf]: https://www.cncf.io/
-[contrib-strat]: https://github.com/cncf/sig-contributor-strategy
+[contrib-strat]: https://github.com/cncf/tag-contributor-strategy
 [devstats]: https://all.devstats.cncf.io/d/22/prs-authors-table?orgId=1
 [dex]: https://github.com/dexidp/dex
 [enhancements]: https://git.k8s.io/enhancements
 [ini]: https://inclusivenaming.org/
+[k8s-steering]: https://git.k8s.io/steering
 [kubecon]: https://kubecon.io
 [kubernetes]: https://kubernetes.io/
+[lf]: https://linuxfoundation.org/
 [releng]: https://git.k8s.io/community/sig-release#release-engineering
 [sig-release]: https://git.k8s.io/community/sig-release
-[steering]: https://git.k8s.io/steering
-[wg-naming]: https://git.k8s.io/community/archive/wg-naming
+[todo-group]: https://todogroup.org/#
+[todo-steering]: https://github.com/todogroup/governance#todo-steering-committee-tsc


### PR DESCRIPTION
- Add TODO Group Steering Committee member
- Add opensource.cisco.com

Signed-off-by: Stephen Augustus <foo@auggie.dev>