### PR TITLE
[2024-08] Content and structure update

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,16 +5,16 @@ tagline = "Caesar of Systems"
 
 Stephen is a Black engineering director and community leader in open source, based in New York City.
 
-He is the Head of [Open Source at Cisco][cisco-open-source], working within the
+He is the Head of [Open Source at Cisco][cisco-open], working within the
 Corporate Strategy, Development, and Incubation (CSDI) organization.
 
-Outside of managing Cisco's open source strategy and a team of brilliant architects in Cisco's Open Source Program Office (OSPO), Stephen participates in foundation-level governing boards (OpenSSF, CNCF, OpenAPI Initiative), project-level steering committees (Kubernetes, OpenSSF Scorecard, TODO Group), and helps maintain a few codebases around open source projects you may have heard of.
+Outside of managing Cisco's open source strategy and a team of brilliant architects in Cisco's Open Source Program Office (OSPO), Stephen participates in foundation-level governing boards ([OpenSSF][ossf], [CNCF][cncf], [OpenAPI Initiative][oapi]), project-level steering committees ([Kubernetes][k8s], [OpenSSF Scorecard][scorecard], [TODO Group][todo]), and helps maintain a few codebases around open source projects you may have heard of.
 
 Additionally, he serves as an advisor and invests in startups with open source in their DNA.
 
 Within the Open Source Security Foundation (OpenSSF), he maintains OpenSSF Scorecard, a project that helps assess the security posture of open source projects.
 
-For [Kubernetes][kubernetes], Stephen serves as a [Steering Committee][k8s-steering] member and a chair of [SIG Release][sig-release].
+For [Kubernetes][k8s], Stephen serves as a [Steering Committee][k8s-steering] member and a chair of [SIG Release][sig-release].
 He has co-founded transformational elements of the project, including the [KEP][enhancements] (Kubernetes Enhancements Proposal) process, the [Release Engineering][releng] subproject, and Working Group Naming. He has previously served as a chair of both SIG PM and SIG Azure.
 
 Across the wider Cloud Native Computing Foundation ([CNCF][cncf]) ecosystem, he is a former [TAG Contributor Strategy][contrib-strat] Chair, [Dex][dex] maintainer, and Program Chair for [KubeCon / CloudNativeCon][kubecon], the cloud native community's flagship conference.
@@ -34,24 +34,22 @@ This is a low-effort way to do link verification for Mastodon.
 Consider rolling this into the partials for the theme:
 https://github.com/escalate/hugo-split-theme/blob/master/layouts/partials/links.html
 -->
+<!-- markdownlint-disable-next-line MD033 -->
 <a rel="me" href="https://hachyderm.io/@justaugustus"></a>
 
-[cisco-open-source]: https://opensource.cisco.com/
+[cisco-open]: https://opensource.cisco.com/
 [cncf]: https://www.cncf.io/
 [contrib-strat]: https://github.com/cncf/tag-contributor-strategy
 [devstats]: https://all.devstats.cncf.io/d/22/prs-authors-table?orgId=1
 [dex]: https://github.com/dexidp/dex
 [enhancements]: https://git.k8s.io/enhancements
 [ini]: https://inclusivenaming.org/
+[k8s]: https://kubernetes.io/
 [k8s-steering]: https://git.k8s.io/steering
 [kubecon]: https://kubecon.io
-[kubernetes]: https://kubernetes.io/
-[lf]: https://linuxfoundation.org/
-[openssf]: https://openssf.org/
-[openssf-gb]: https://openssf.org/about/board/
-[oapi-initiative]: https://www.openapis.org/
+[oapi]: https://www.openapis.org/
+[ossf]: https://openssf.org/
 [releng]: https://git.k8s.io/community/sig-release#release-engineering
 [scorecard]: https://github.com/ossf/scorecard
 [sig-release]: https://git.k8s.io/community/sig-release
-[todo-group]: https://todogroup.org/#
-[todo-steering]: https://github.com/todogroup/governance
+[todo]: https://todogroup.org/

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,34 +3,23 @@ title = "Stephen Augustus"
 tagline = "Caesar of Systems"
 +++
 
-Stephen is a Black engineering director and leader in open source communities.
+Stephen is a Black engineering director and leader in open source communities, based in New York City.
 
 He is the Head of [Open Source at Cisco][cisco-open-source], working within the
-Strategy, Incubation, & Applications (SIA) organization.
+Corporate Strategy, Development, and Incubation (CSDI) organization.
 
-For [Kubernetes][kubernetes], he has co-founded transformational elements of
-the project, including the [KEP][enhancements] (Kubernetes Enhancements
-Proposal) process, the [Release Engineering][releng] subproject, and Working
-Group Naming. Stephen has also previously served as a chair for both SIG PM and
-SIG Azure.
+Outside of managing Cisco's open source strategy and a team of brilliant architects in Cisco's Open Source Program Office (OSPO), Stephen participates in foundation-level governing boards (OpenSSF, CNCF, OpenAPI Initiative, project-level steering committees (Kubernetes, OpenSSF Scorecard, TODO Group), and helps maintain a few codebases around open source projects you may have heard of.
 
-He continues his work in Kubernetes as a [Steering Committee][k8s-steering]
-member and a Chair for [SIG Release][sig-release].
+Additionally, he serves as an advisor and invests in startups with open source in their DNA.
 
-Across the wider [LF][lf] (Linux Foundation) ecosystem, Stephen has the
-pleasure of serving as a member of the [OpenSSF][openssf]
-[Governing Board][openssf-gb] and the [OpenAPI Initiative][oapi-initiative]
-Business Governing Board.
+Within the Open Source Security Foundation, he maintains OpenSSF Scorecard, a project that can help you assess the security posture of open source projects.
 
-Previously, he was a [TODO Group][todo-group] [Steering Committee][todo-steering]
-member, a [CNCF][cncf] (Cloud Native Computing Foundation)
-[TAG Contributor Strategy][contrib-strat] Chair, and one of the Program Chairs
-for [KubeCon / CloudNativeCon][kubecon], the cloud native community's flagship
-conference.
+For [Kubernetes][kubernetes], Stephen serves as a [Steering Committee][k8s-steering] member and a Chair for [SIG Release][sig-release].
+He has co-founded transformational elements of the project, including the [KEP][enhancements] (Kubernetes Enhancements Proposal) process, the [Release Engineering][releng] subproject, and Working Group Naming. He has also previously served as a chair for both SIG PM and SIG Azure.
 
-He is a maintainer for the [Scorecard][scorecard] and [Dex][dex] projects, and
-a [prolific contributor][devstats] to CNCF projects, amongst the top 40
-(as of writing) code/content committers, all-time.
+Across the wider Cloud Native Computing Foundation ([CNCF][cncf]) ecosystem, he is a former [TAG Contributor Strategy][contrib-strat] Chair, [Dex][dex] maintainer, and Program Chair for [KubeCon / CloudNativeCon][kubecon], the cloud native community's flagship conference.
+
+Stephen is a [prolific contributor][devstats] to CNCF projects, amongst the top 100 (as of writing) code/content committers since inception of the foundation.
 
 In 2020, Stephen co-founded the [Inclusive Naming Initiative][ini], a
 cross-industry group dedicated to helping projects and companies make
@@ -38,8 +27,6 @@ consistent, responsible choices to remove harmful language across codebases,
 standards, and documentation.
 
 He has previously held positions at VMware (via Heptio), Red Hat, and CoreOS.
-
-Stephen is based in New York City.
 
 <!-- FIXME:
 This is a low-effort way to do link verification for Mastodon.

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,23 +3,40 @@ title = "Stephen Augustus"
 tagline = "Caesar of Systems"
 +++
 
-Stephen is a Black engineering director and community leader in open source, based in New York City.
+Stephen is a Black engineering director and community leader in open source,
+based in New York City.
 
 He is the Head of [Open Source at Cisco][cisco-open], working within the
 Corporate Strategy, Development, and Incubation (CSDI) organization.
 
-Outside of managing Cisco's open source strategy and a team of brilliant architects in Cisco's Open Source Program Office (OSPO), Stephen participates in foundation-level governing boards ([OpenSSF][ossf], [CNCF][cncf], [OpenAPI Initiative][oapi]), project-level steering committees ([Kubernetes][k8s], [OpenSSF Scorecard][scorecard], [TODO Group][todo]), and helps maintain a few codebases around open source projects you may have heard of.
+Outside of managing Cisco's open source strategy and a team of brilliant
+architects in Cisco's Open Source Program Office (OSPO), Stephen participates
+in foundation-level governing boards ([OpenSSF][ossf], [CNCF][cncf],
+[OpenAPI Initiative][oapi]), project-level steering committees
+([Kubernetes][k8s], [OpenSSF Scorecard][scorecard], [TODO Group][todo]), and
+helps maintain a few codebases around open source projects you may have heard of.
 
 Additionally, he serves as an advisor and invests in startups with open source in their DNA.
 
-Within the Open Source Security Foundation (OpenSSF), he maintains OpenSSF Scorecard, a project that helps assess the security posture of open source projects.
+Within the Open Source Security Foundation (OpenSSF), he maintains OpenSSF
+Scorecard, a project that helps assess the security posture of open source
+projects.
 
-For [Kubernetes][k8s], Stephen serves as a [Steering Committee][k8s-steering] member and a chair of [SIG Release][sig-release].
-He has co-founded transformational elements of the project, including the [KEP][enhancements] (Kubernetes Enhancements Proposal) process, the [Release Engineering][releng] subproject, and Working Group Naming. He has previously served as a chair of both SIG PM and SIG Azure.
+For [Kubernetes][k8s], Stephen serves as a [Steering Committee][k8s-steering]
+member and a chair of [SIG Release][sig-release].
+He has co-founded transformational elements of the project, including the
+[KEP][enhancements] (Kubernetes Enhancements Proposal) process, the
+[Release Engineering][releng] subproject, and Working Group Naming. He has
+previously served as a chair of both SIG PM and SIG Azure.
 
-Across the wider Cloud Native Computing Foundation ([CNCF][cncf]) ecosystem, he is a former [TAG Contributor Strategy][contrib-strat] Chair, [Dex][dex] maintainer, and Program Chair for [KubeCon / CloudNativeCon][kubecon], the cloud native community's flagship conference.
+Across the wider Cloud Native Computing Foundation ([CNCF][cncf]) ecosystem, he
+is a former [TAG Contributor Strategy][contrib-strat] Chair, [Dex][dex]
+maintainer, and Program Chair for [KubeCon / CloudNativeCon][kubecon], the
+cloud native community's flagship conference.
 
-Stephen is a [prolific contributor][devstats] to CNCF projects, and is amongst the top 100 (as of writing) code/content committers since the inception of the foundation.
+Stephen is a [prolific contributor][devstats] to CNCF projects, and is amongst
+the top 100 (as of writing) code/content committers since the inception of the
+foundation.
 
 In 2020, Stephen co-founded the [Inclusive Naming Initiative][ini], a
 cross-industry group dedicated to helping projects and companies make

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Stephen Augustus"
-tagline = "Caesar of Systems"
+tagline = "Open Enthusiast"
 +++
 
 Stephen is a Black engineering director and community leader in open source,

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,23 +3,23 @@ title = "Stephen Augustus"
 tagline = "Caesar of Systems"
 +++
 
-Stephen is a Black engineering director and leader in open source communities, based in New York City.
+Stephen is a Black engineering director and community leader in open source, based in New York City.
 
 He is the Head of [Open Source at Cisco][cisco-open-source], working within the
 Corporate Strategy, Development, and Incubation (CSDI) organization.
 
-Outside of managing Cisco's open source strategy and a team of brilliant architects in Cisco's Open Source Program Office (OSPO), Stephen participates in foundation-level governing boards (OpenSSF, CNCF, OpenAPI Initiative, project-level steering committees (Kubernetes, OpenSSF Scorecard, TODO Group), and helps maintain a few codebases around open source projects you may have heard of.
+Outside of managing Cisco's open source strategy and a team of brilliant architects in Cisco's Open Source Program Office (OSPO), Stephen participates in foundation-level governing boards (OpenSSF, CNCF, OpenAPI Initiative), project-level steering committees (Kubernetes, OpenSSF Scorecard, TODO Group), and helps maintain a few codebases around open source projects you may have heard of.
 
 Additionally, he serves as an advisor and invests in startups with open source in their DNA.
 
-Within the Open Source Security Foundation, he maintains OpenSSF Scorecard, a project that can help you assess the security posture of open source projects.
+Within the Open Source Security Foundation (OpenSSF), he maintains OpenSSF Scorecard, a project that helps assess the security posture of open source projects.
 
-For [Kubernetes][kubernetes], Stephen serves as a [Steering Committee][k8s-steering] member and a Chair for [SIG Release][sig-release].
-He has co-founded transformational elements of the project, including the [KEP][enhancements] (Kubernetes Enhancements Proposal) process, the [Release Engineering][releng] subproject, and Working Group Naming. He has also previously served as a chair for both SIG PM and SIG Azure.
+For [Kubernetes][kubernetes], Stephen serves as a [Steering Committee][k8s-steering] member and a chair of [SIG Release][sig-release].
+He has co-founded transformational elements of the project, including the [KEP][enhancements] (Kubernetes Enhancements Proposal) process, the [Release Engineering][releng] subproject, and Working Group Naming. He has previously served as a chair of both SIG PM and SIG Azure.
 
 Across the wider Cloud Native Computing Foundation ([CNCF][cncf]) ecosystem, he is a former [TAG Contributor Strategy][contrib-strat] Chair, [Dex][dex] maintainer, and Program Chair for [KubeCon / CloudNativeCon][kubecon], the cloud native community's flagship conference.
 
-Stephen is a [prolific contributor][devstats] to CNCF projects, amongst the top 100 (as of writing) code/content committers since inception of the foundation.
+Stephen is a [prolific contributor][devstats] to CNCF projects, and is amongst the top 100 (as of writing) code/content committers since the inception of the foundation.
 
 In 2020, Stephen co-founded the [Inclusive Naming Initiative][ini], a
 cross-industry group dedicated to helping projects and companies make

--- a/content/_index.md
+++ b/content/_index.md
@@ -16,7 +16,8 @@ in foundation-level governing boards ([OpenSSF][ossf], [CNCF][cncf],
 ([Kubernetes][k8s], [OpenSSF Scorecard][scorecard], [TODO Group][todo]), and
 helps maintain a few codebases around open source projects you may have heard of.
 
-Additionally, he serves as an advisor and invests in startups with open source in their DNA.
+Additionally, he serves as an advisor and investor for startups in the open
+source ecosystem.
 
 Within the Open Source Security Foundation (OpenSSF), he maintains OpenSSF
 Scorecard, a project that helps assess the security posture of open source


### PR DESCRIPTION
- Update Cisco organization name to CSDI
- Update roles:
  - Add TODO Group Steering Committee (returning)
  - Add OpenSSF Scorecard Steering Committee (new)
  - Remove Dex (emeritus)
  - Mention advisory roles and investments